### PR TITLE
Show file size for each group

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -63,6 +63,11 @@ function loadList() {
                         element.appendChild(group);
                     }
                     group = getGroupeDiv();
+                    // Show size
+                    size = document.createElement("div");
+                    size.setAttribute('class', 'filesize');
+                    size.innerHTML = OC.Util.humanFileSize(el.infos.size);
+                    group.prepend(size);
                     group.appendChild(div);
                 }
                 previous_hash = el.hash;


### PR DESCRIPTION
Hi! 

I added the size of the element on the `duplicates` group, so you can choose what duplicates are more important to delete.