### PR TITLE
Update margin around loading container.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -48,7 +48,7 @@
 	100% { transform: rotate(360deg); }
   }
 #loader-container{
-	margin: 50%;
+	margin: 1em 50% 1em 50%;
 }
 #title{
 	 width: 300px;


### PR DESCRIPTION
Loading image disappeared, but it was on the bottom of the page (see #8).

Here it is a patch to solve it.