### PR TITLE
Changed Indexing for Paths

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,6 +37,7 @@ jobs:
           MYSQL_USER: ${{ env.DB_USER }}
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
         options: >-
+          --health-cmd "mysqladmin ping -u ${{env.DB_USER}} -p${{ env.DB_PASSWORD }}"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -49,6 +50,7 @@ jobs:
           MYSQL_USER: ${{ env.DB_USER }}
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
         options: >-
+          --health-cmd "mysqladmin ping -u ${{env.DB_USER}} -p${{ env.DB_PASSWORD }}"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,7 @@ on:
     paths: '**.php'
   workflow_dispatch:
 env:
-  DB_USER: nc_test
+  DB_USER: root
   DB_PASSWORD: nc_test
   DATABASE: nc_test
 jobs:
@@ -31,31 +31,24 @@ jobs:
         ports:
           - 5432:5432
       mariadb:
-        image: mariadb
-        env:
-          MYSQL_DATABASE: ${{ env.DATABASE }}
-          MYSQL_USER: ${{ env.DB_USER }}
-          MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
-        options: >-
-          --health-cmd "mysqladmin ping -u nc_test -pnc_test"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+         # Nextcloud Requires compressed tables which are not supported in 10.6 (nextcloud/server #25436)
+        image: mariadb:10.5
         ports:
           - 3306:3306
-      mysql:
-        image: mysql
         env:
           MYSQL_DATABASE: ${{ env.DATABASE }}
-          MYSQL_USER: ${{ env.DB_USER }}
-          MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
-        options: >-
-          --health-cmd "mysqladmin ping -u nc_test -pnc_test"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          MYSQL_ROOT_PASSWORD: ${{ env.DB_PASSWORD }}
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+      mysql:
+         # Nextcloud Requires compressed tables which are not supported in 10.6 (nextcloud/server #25436)
+        image: chrros95/mysql
         ports:
           - 3307:3306
+        env:
+          MYSQL_DATABASE: ${{ env.DATABASE }}
+          MYSQL_ROOT_PASSWORD: ${{ env.DB_PASSWORD }}
+          AUTH_PLUGIN: mysql_native_password
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     strategy:
       matrix:
         php-versions: ['7.3', '7.4']
@@ -75,7 +68,6 @@ jobs:
             dbport: 5432
           - database: mariadb
             dbtype: mysql
-            dbport: 3306
           - database: mysql
             dbport: 3307
     steps:
@@ -96,7 +88,7 @@ jobs:
           cron: true
           database-type: ${{ matrix.dbtype || matrix.database }}
           database-host: 127.0.0.1
-          database-port: ${{ matrix.dbport }}
+          database-port: ${{ matrix.dbport || 3306 }}
           database-name: ${{ env.DATABASE }}
           database-user: ${{ env.DB_USER }}
           database-password: ${{ env.DB_PASSWORD }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -85,7 +85,7 @@ jobs:
           version: ${{ matrix.nextcloud }}
           cron: true
           database-type: ${{ matrix.dbtype || matrix.database }}
-          database-host: 'localhost'
+          database-host: 127.0.0.1
           database-port: ${{ matrix.dbport }}
           database-name: ${{ env.DATABASE }}
           database-user: ${{ env.DB_USER }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 env:
   DB_USER: nc_test
-  DB_PASSWORD: nc_test_db
+  DB_PASSWORD: nc_test
   DATABASE: nc_test
 jobs:
   integration:
@@ -37,7 +37,7 @@ jobs:
           MYSQL_USER: ${{ env.DB_USER }}
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
         options: >-
-          --health-cmd "mysqladmin ping -u ${{env.DB_USER}} -p${{ env.DB_PASSWORD }}"
+          --health-cmd "mysqladmin ping -u nc_test -pnc_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -50,7 +50,7 @@ jobs:
           MYSQL_USER: ${{ env.DB_USER }}
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
         options: >-
-          --health-cmd "mysqladmin ping -u ${{env.DB_USER}} -p${{ env.DB_PASSWORD }}"
+          --health-cmd "mysqladmin ping -u nc_test -pnc_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,6 +36,10 @@ jobs:
           MYSQL_DATABASE: ${{ env.DATABASE }}
           MYSQL_USER: ${{ env.DB_USER }}
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+        options: >-
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           - 3306:3306
       mysql:
@@ -44,6 +48,10 @@ jobs:
           MYSQL_DATABASE: ${{ env.DATABASE }}
           MYSQL_USER: ${{ env.DB_USER }}
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+        options: >-
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           - 3307:3306
     strategy:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,12 +7,9 @@ on:
   pull_request:
     paths: '**.php'
 env:
-  POSTGRES_PASSWORD: nc_test_db
-  MYSQL_USER: nc_test
-  MYSQL_PASSWORD: nc_test_db
-  MYSQL_DATABASE: nc_test
-  MYSQL_PORT: 3800
-
+  DB_USER: nc_test
+  DB_PASSWORD: nc_test_db
+  DATABASE: nc_test
 jobs:
   integration:
     runs-on: ubuntu-latest
@@ -22,19 +19,37 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: ${{ env.POSTGRES_PASSWORD }}
+          POSTGRES_DB: ${{ env.DATABASE }}
+          POSTGRES_USER: ${{ env.DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 5432:5432 # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+      mariadb:
+        image: mariadb
+        env:
+          MYSQL_DATABASE: ${{ env.DATABASE }}
+          MYSQL_USER: ${{ env.DB_USER }}
+          MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+        ports:
+          - 3306:3306
+      mysql:
+        image: mysql
+        env:
+          MYSQL_DATABASE: ${{ env.DATABASE }}
+          MYSQL_USER: ${{ env.DB_USER }}
+          MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}
+        ports:
+          - 3307:3306
     strategy:
       matrix:
         php-versions: ['7.3', '7.4']
-        nextcloud: ['stable20', 'stable21']
-        database: ['sqlite', 'pgsql', 'mysql']
+        nextcloud: ['stable20', 'stable21', 'stable22']
+        database: ['sqlite', 'pgsql', 'mysql','mariadb']
         experimental: [false]
         include:
           - php-versions: 7.4
@@ -45,76 +60,48 @@ jobs:
             nextcloud: pre-release
             database: sqlite
             experimental: true
+          - database: pgsql
+            dbport: 5432
+          - database: mariadb
+            dbtype: mysql
+            dbport: 3306
+          - database: mysql
+            dbport: 3307
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: pdo_sqlite,pdo_mysql,pdo_pgsql,gd,zip
           coverage: none
-
       - name: Setup BATS
         uses: mig4/setup-bats@v1
-
-      ### MySQL specific setup
-      - name: Setup mysql
-        if: matrix.database == 'mysql'
-        uses: getong/mariadb-action@v1.1
-        with:
-          host port: ${{ env.MYSQL_PORT }}
-          mysql database: ${{ env.MYSQL_DATABASE }}
-          mysql root password: ${{ env.MYSQL_PASSWORD }}
-          mysql user: ${{ env.MYSQL_USER }}
-          mysql password: ${{ env.MYSQL_PASSWORD }}
-
-      - name: Set up server MySQL
-        if: matrix.database == 'mysql'
+      - name: Set up server
         uses: SMillerDev/nextcloud-actions/setup-nextcloud@main
         with:
           version: ${{ matrix.nextcloud }}
           cron: true
-          database-type: ${{ matrix.database }}
-          database-host: 127.0.0.1
-          database-port: ${{ env.MYSQL_PORT }}
-          database-name: ${{ env.MYSQL_DATABASE }}
-          database-user: root
-          database-password: ${{ env.MYSQL_PASSWORD }}
-
-      ### Back to normal setup
-      - name: Set up server non MySQL
-        if: matrix.database != 'mysql'
-        uses: SMillerDev/nextcloud-actions/setup-nextcloud@main
-        with:
-          version: ${{ matrix.nextcloud }}
-          cron: true
-          database-type: ${{ matrix.database }}
-          database-host: localhost
-          database-port: 5432
-          database-name: postgres
-          database-user: postgres
-          database-password: ${{ env.POSTGRES_PASSWORD }}
-
+          database-type: ${{ matrix.dbtype || matrix.database }}
+          database-host: 'localhost'
+          database-port: ${{ matrix.dbport }}
+          database-name: ${{ env.DATABASE }}
+          database-user: ${{ env.DB_USER }}
+          database-password: ${{ env.DB_PASSWORD }}
       - name: Prime app build
         run: make
-
       - name: Configure server with app
         uses: SMillerDev/nextcloud-actions/setup-nextcloud-app@main
         with:
           app: 'duplicatefinder'
           check-code: true
           force: ${{ matrix.experimental }}
-
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
       - name: Functional tests maintenance
         working-directory: ../server
-        run: |
-          ./occ maintenance:repair
-
+        run: ./occ maintenance:repair
       - name: Functional tests
         working-directory: ../server
         run: bats apps/duplicatefinder/tests/bats

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,6 +6,7 @@ on:
     paths: '**.php'
   pull_request:
     paths: '**.php'
+  workflow_dispatch:
 env:
   DB_USER: nc_test
   DB_PASSWORD: nc_test_db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.10
+- Added Support for MySQL as database
+
 ## 0.0.9
 
 - Restored 0.0.7 with fixes

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -50,7 +50,7 @@
     ![Preview of the GUI](https://raw.githubusercontent.com/PaulLereverend/NextcloudDuplicateFinder/master/img/preview.png)
 ]]>
   </description>
-  <version>0.0.9</version>
+  <version>0.0.10</version>
   <licence>agpl</licence>
   <author mail="paulereverend@gmail.com" >Paul Lereverend</author>
   <namespace>DuplicateFinder</namespace>

--- a/lib/Db/FileDuplicate.php
+++ b/lib/Db/FileDuplicate.php
@@ -1,6 +1,14 @@
 <?php
 namespace OCA\DuplicateFinder\Db;
 
+/**
+ * @method void setType(string $s)
+ * @method void setHash(string $s)
+ * @method void setFiles(array<string|FileInfo> $a)
+ * @method string getType()
+ * @method string getHash()
+ * @method array<string|FileInfo> getFiles()
+ */
 class FileDuplicate extends EEntity
 {
 

--- a/lib/Db/FileInfo.php
+++ b/lib/Db/FileInfo.php
@@ -1,6 +1,26 @@
 <?php
 namespace OCA\DuplicateFinder\Db;
 
+/**
+ * @method void setOwner(string $s)
+ * @method void setPath(string $s)
+ * @method void setPathHash(string $s)
+ * @method void setFileHash(string $s)
+ * @method void setImageHash(string $s)
+ * @method void setUpdatedAt(int|\DateTime $d)
+ * @method void setNodeId(int $i)
+ * @method void setMimetype(string $s)
+ * @method void setSize(int $i)
+ * @method string getOwner()
+ * @method string getPath()
+ * @method string getPathHash()
+ * @method string getFileHash()
+ * @method string getImageHash()
+ * @method \DateTime getUpdatedAt()
+ * @method int getNodeId()
+ * @method string getMimetype()
+ * @method int getSize()
+ */
 class FileInfo extends EEntity
 {
 
@@ -8,6 +28,8 @@ class FileInfo extends EEntity
     protected $owner;
     /** @var string */
     protected $path;
+    /** @var string */
+    protected $pathHash;
     /** @var string */
     protected $fileHash;
     /** @var string */
@@ -33,5 +55,12 @@ class FileInfo extends EEntity
         if (!is_null($owner)) {
             $this->setOwner($owner);
         }
+    }
+
+    public function setPath(string $path):void
+    {
+        // SHA1 because we need a function to short the path and not be cryptographically secure
+        $this->setPathHash(sha1($path));
+        parent::setPath($path);
     }
 }

--- a/lib/Db/FileInfoMapper.php
+++ b/lib/Db/FileInfoMapper.php
@@ -24,7 +24,7 @@ class FileInfoMapper extends EQBMapper
         $qb->select('*')
         ->from($this->getTableName())
         ->where(
-            $qb->expr()->eq('path', $qb->createNamedParameter($path))
+            $qb->expr()->eq('path_hash', $qb->createNamedParameter(sha1($path)))
         );
         return $this->findEntity($qb);
     }

--- a/lib/Migration/Version0003Date20210715132400.php
+++ b/lib/Migration/Version0003Date20210715132400.php
@@ -10,7 +10,7 @@ use OCP\DB\ISchemaWrapper;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
-class Version0001Date20210508222200 extends SimpleMigrationStep
+class Version0003Date20210715132400 extends SimpleMigrationStep
 {
 
   /**
@@ -25,10 +25,17 @@ class Version0001Date20210508222200 extends SimpleMigrationStep
         $schema = $schemaClosure();
         if ($schema->hasTable('duplicatefinder_finfo')) {
             $table = $schema->getTable('duplicatefinder_finfo');
-            if ($table->hasColumn('path')) {
-                $pathColumn = $table->getColumn('path');
-                $pathColumn->setType(Type::getType(Types::STRING));
-                $pathColumn->setOptions(['length' => 4000]);
+            if ($table->hasIndex('duplicatefinder_path_idx')) {
+                $table->dropIndex('duplicatefinder_path_idx');
+            }
+            if (!$table->hasColumn('path_hash')) {
+                $table->addColumn('path_hash', 'string', [
+                  'notnull' => true,
+                  'length' => 40,
+                ]);
+            }
+            if (!$table->hasIndex('duplicatefinder_ph_idx')) {
+                $table->addIndex(['path_hash'], 'duplicatefinder_ph_idx');
             }
             return $schema;
         }

--- a/lib/Service/FileInfoService.php
+++ b/lib/Service/FileInfoService.php
@@ -178,10 +178,15 @@ class FileInfoService
           $fileInfo->getUpdatedAt()->getTimestamp()
         || $file->getUploadTime() >
           $fileInfo->getUpdatedAt()->getTimestamp())) {
-            $fileInfo->setFileHash($file->getStorage()->hash('sha256', $file->getInternalPath()));
-            $fileInfo->setUpdatedAt(new \DateTime());
-            $this->update($fileInfo);
-            $this->eventDispatcher->dispatchTyped(new CalculatedHashEvent($fileInfo, $oldHash));
+             $hash = $file->getStorage()->hash('sha256', $file->getInternalPath());
+            if (!is_bool($hash)) {
+                $fileInfo->setFileHash($hash);
+                $fileInfo->setUpdatedAt(new \DateTime());
+                $this->update($fileInfo);
+                $this->eventDispatcher->dispatchTyped(new CalculatedHashEvent($fileInfo, $oldHash));
+            } else {
+                throw new \Exception('Unable to calculate hash for '.$file->getInternalPath());
+            }
         }
         return $fileInfo;
     }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,4 +5,4 @@ parameters:
   bootstrapFiles:
     - %currentWorkingDirectory%/../../lib/base.php
   ignoreErrors:
-    - '#Call to an undefined method OCA\\DuplicateFinder\\Db\\((?!EEntity).)+::(s|g)et[A-Z].+\(\)#'
+    - '#Call to an undefined static method OCA\\DuplicateFinder\\Db\\EEntity::(s|g)et[A-Z].+\(\).#'


### PR DESCRIPTION
Issue #32 #34 #35 showed that the current code base doesn't support MySQL as database because it handles indexes  differently than MariaDB. While MariaDB accepts indexes that need more space than available MySQL throws an error. The affected index was over a column that stores the file path.

To avoid this a new column has been added which stores a shorten version (hash) of the path.

For future developments testing for MySQL has been added. 