### PR TITLE
Catch NoUserException from shared files from Talk

### DIFF
--- a/lib/Service/FileInfoService.php
+++ b/lib/Service/FileInfoService.php
@@ -6,6 +6,7 @@ use OCP\IDBConnection;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
+use OC\User\NoUserException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use OCA\DuplicateFinder\AppInfo\Application;
@@ -278,7 +279,7 @@ class FileInfoService
                     $fileInfo->setPath($path);
                     $result = $fileInfo;
                 }
-            } catch (NotFoundException $e) {
+            } catch (NoUserException | NotFoundException $e) {
                 $result = null;
             }
         }


### PR DESCRIPTION
Files from the Talk app appear as shared links in the user's files. Current Nextcloud code is giving NoSuchUser exception on these files. Catch that exception and skip the files from duplicate tracking, since we do not own them.